### PR TITLE
Prevent sending additional keep alive

### DIFF
--- a/src/WebsocketConnection.js
+++ b/src/WebsocketConnection.js
@@ -39,6 +39,14 @@ export default class WebsocketConnection {
     }
     this.socket.onclose = () => {
       console.log('websocket close')
+      if (this._keepAliveIntervalHandler) {
+        clearTimeout(this._keepAliveIntervalHandler)
+        this._previousKeepAliveInterval = null
+      }
+      if (this._keepAliveTimeoutHandler) {
+        clearTimeout(this._keepAliveTimeoutHandler)
+        this._previousKeepAliveTimeout = null
+      }
       document.dispatchEvent(
         new window.CustomEvent('wsclose', { bubbles: true })
       )
@@ -101,7 +109,7 @@ export default class WebsocketConnection {
     }
   }
   send (message) {
-    if (this.socket) {
+    if (this.socket && this.socket.readyState === this.socket.OPEN) {
       this.socket.send(message)
     }
   }


### PR DESCRIPTION
I add a condition to prevent a keep-alive message while the socket is closed. I clear sending keep alive and closing connection time out on close event to prevent if there is a socket.close in the event queue when we reopening socket connection. closes #8 